### PR TITLE
Implement transaction form figure out fluent UI in unit tests

### DIFF
--- a/tests/components/TheForm.test.ts
+++ b/tests/components/TheForm.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { render, RenderResult, screen } from '@testing-library/vue';
 import { plugin, defaultConfig } from '@formkit/vue';
 import { createTestingPinia } from '@pinia/testing';
-import { provideFluentDesignSystem } from '@fluentui/web-components';
 import TheForm from '@components/TheForm.vue';
 
 // Registering global plugins (FormKit, for instance) in test
@@ -10,7 +9,12 @@ import TheForm from '@components/TheForm.vue';
 
 // LINK Testing Pinia in components: https://pinia.vuejs.org/cookbook/testing.html#unit-testing-components
 
-describe('TheForm', () => {
+// Mock window.matchMedia: https://stackoverflow.com/a/42685938
+// Using vi from vitest instead of jest
+
+describe('TheForm', async () => {
+  await import('@config/injectFluentDesignSystem');
+
   describe('Rendering', () => {
     let dom: RenderResult;
 
@@ -20,7 +24,6 @@ describe('TheForm', () => {
           plugins: [[plugin, defaultConfig(), createTestingPinia()]],
         },
       });
-      // provideFluentDesignSystem(dom.baseElement as HTMLElement);
     });
 
     describe('the correct fields', () => {
@@ -32,6 +35,11 @@ describe('TheForm', () => {
         'emoji',
         'currency',
       ];
+
+      it('test', async () => {
+        const el: HTMLInputElement = await screen.findByLabelText('Currency');
+        console.log(el.value);
+      });
 
       it('should have the correct amount of fields', () => {
         const foundElements = document.querySelectorAll('label');

--- a/tests/utils/mockMatchMedia.ts
+++ b/tests/utils/mockMatchMedia.ts
@@ -1,0 +1,15 @@
+import { vi } from 'vitest';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     globals: true,
     include: ['tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     environment: 'jsdom',
+    setupFiles: ['./tests/utils/mockMatchMedia.ts'],
   },
   resolve: { alias },
 });


### PR DESCRIPTION
# What's new?

Nothing new, but learned more about the `testing-library`, how to setup testing environment to inject Fluent UI web components to testing context, and how to access and test custom web components' underlying native HTML elements. 